### PR TITLE
Adds ability to run container in detached mode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 config.json
 plugins.txt
 tags
+persist
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM hypriot/rpi-node:8
 MAINTAINER ViViDboarder <vividboarder@gmail.com>
 
-RUN [ "cross-build-start" ]
-
 ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
@@ -11,6 +9,7 @@ RUN apt-get update && \
         avahi-daemon \
         avahi-discover \
         build-essential \
+	iputils-ping \
         libavahi-compat-libdnssd-dev \
         libnss-mdns && \
         apt-get clean && \
@@ -34,7 +33,6 @@ RUN mkdir -p /var/run/dbus/
 USER root
 RUN mkdir -p /root/.homebridge
 
-RUN [ "cross-build-end" ]
 
 EXPOSE 5353 51826
 VOLUME /root/.homebridge

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM hypriot/rpi-node:7
-# FROM hypriot/rpi-node:6.9.1
+FROM hypriot/rpi-node:latest
 MAINTAINER ViViDboarder <vividboarder@gmail.com>
 
 ENV LANG en_US.UTF-8
@@ -14,8 +13,10 @@ RUN apt-get install -y --no-install-recommends \
         libnss-mdns && \
         apt-get clean && \
         rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+ 
+RUN apt-get update && apt-get install libpcap-dev iputils-ping
 
-RUN apt-get update && apt-get install iputils-ping 
+RUN npm config set unsafe-perm true
 
 RUN npm install -g --unsafe-perm \
         homebridge \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN apt-get install -y --no-install-recommends \
         apt-get clean && \
         rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+RUN apt-get update && apt-get install iputils-ping 
+
 RUN npm install -g --unsafe-perm \
         homebridge \
         hap-nodejs \

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,6 @@ shell: build
 
 # Target to buld and run in detached mode (continuously)
 go: build
-	make clean
 	docker run --net=host -d \
 		-p "51826:51826" \
 		-v "$(shell pwd)/config.json:/root/.homebridge/config.json" \

--- a/Makefile
+++ b/Makefile
@@ -4,21 +4,38 @@ default: build
 build:
 	docker build -t rpi-homebridge-dev .
 
+clean:
+	-docker kill homebridge
+	-docker rm homebridge
+
 # Target to build and run and subsequently remove image
 run: build
 	docker run --net=host --rm \
-		-p "localhost:51826:51826"
+		-p "51826:51826" \
 		-v "$(shell pwd)/config.json:/root/.homebridge/config.json" \
 		-v "$(shell pwd)/plugins.txt:/root/.homebridge/plugins.txt" \
+		-v "$(shell pwd)/persist:/root/.homebridge/persist" \
 		rpi-homebridge-dev
 
 # Target to drop into an interractive shell
 shell: build
 	docker run --net=host --rm \
-		-p "localhost:51826:51826"
+		-p "51826:51826" \
 		-v "$(shell pwd)/config.json:/root/.homebridge/config.json" \
 		-v "$(shell pwd)/plugins.txt:/root/.homebridge/plugins.txt" \
+		-v "$(shell pwd)/persist:/root/.homebridge/persist" \
 		-it rpi-homebridge-dev bash
+
+# Target to buld and run in detached mode (continuously)
+go: build
+	make clean
+	docker run --net=host -d \
+		-p "51826:51826" \
+		-v "$(shell pwd)/config.json:/root/.homebridge/config.json" \
+		-v "$(shell pwd)/plugins.txt:/root/.homebridge/plugins.txt" \
+		-v "$(shell pwd)/persist:/root/.homebridge/persist" \
+		--name homebridge \
+		rpi-homebridge-dev
 
 # Tags dev image so it can be pushed
 tag: build

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ go: build
 		-v "$(shell pwd)/plugins.txt:/root/.homebridge/plugins.txt" \
 		-v "$(shell pwd)/persist:/root/.homebridge/persist" \
 		--name homebridge \
+		--restart=always \
 		rpi-homebridge-dev
 
 # Tags dev image so it can be pushed

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,3 +6,4 @@ homebridge:
   volumes:
     - ./config.json:/root/.homebridge/config.json
     - ./plugins.txt:/root/.homebridge/plugins.txt
+    - ./persist:/root/.homebridge/persist


### PR DESCRIPTION
This change also mounts the "persist" folder so we dont lose the
homebridge devices in the app on rebuilds.

Ping is also installed in the container as a few homebridge plugins
such as `homebridge-people` and `homebridge-lgtv2` depend on ping.